### PR TITLE
Fix to ensure plugin is correctly renamed when cwd in not project root.

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ function rename(filepath, options) {
   filepath = utils.relative(filepath);
 
   if (/node_modules/.test(filepath)) {
-    name = utils.segments(filepath, 1, 2);
+    name = utils.segments(filepath.replace(/.*\/(?=node_modules)/,''), 1, 2);
   } else {
     name = utils.basename(filepath);
   }

--- a/test/test.js
+++ b/test/test.js
@@ -37,4 +37,12 @@ describe('plugins', function () {
       }
     }).should.have.properties(['a', 'b', 'c']);
   });
+
+  it('Should correctly rename plugin when cwd is not at project root.', function () {
+    var originalCwd = process.cwd();
+
+    process.chdir(__dirname);
+    plugins('gulp-*').should.have.properties(['mocha']);
+    process.chdir(originalCwd);
+  });
 });


### PR DESCRIPTION
Currently load-plugins assumes the cwd is the project root. This PR fixes the behavior by ensuring the correct segment is utilized.
- I opened this PR against `master`, but I would happy to open it against `next` if you would rather.
