### PR TITLE
Bump to resolve-dep v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "app-name": "^0.2.0",
     "extend-shallow": "^2.0.0",
-    "resolve-dep": "^0.5.3"
+    "resolve-dep": "^0.6.0"
   },
   "devDependencies": {
     "gulp": "^3.8.7",


### PR DESCRIPTION
Pending https://github.com/jonschlinkert/resolve-dep/pull/9.

Upon approval would tag/release patch as v2.1.2